### PR TITLE
Adding support for detecting a POM file

### DIFF
--- a/src/main/scala/com/github/shivawu/sbt/maven/MavenPlugin.scala
+++ b/src/main/scala/com/github/shivawu/sbt/maven/MavenPlugin.scala
@@ -4,30 +4,31 @@ import sbt._
 
 object MavenPlugin extends Plugin {
   override val settings: Seq[Setting[_]] = {
-    
+    val pomFile = new java.io.File("./pom.xml")
+
     val res: Seq[Setting[_]] = MavenBuild.getInstanceClassName match {
       case Some(buildClass) => 
-        // User has defined a MavenBuild object
-        // So we should not import pom.xml here
-        ConsoleLogger().info("Use user-defined Build class of [" + buildClass + "]")
+        ConsoleLogger().info("Using user-defined Build class of [" + buildClass + "]")
         Seq()
       case None =>
-        val pom = Pom(new java.io.File("./pom.xml"))
-        val noModuleDef = pom.modules.isEmpty
-        // If this is a multiple module pom, we won't do anything
-        if (noModuleDef) {
-          // Here we should use log.info, but I don't know how
-          // UPDATE: I figured it out!! Use ConsoleLogger().info
-          //         SBT's documentation and design is unbelievable!
-          ConsoleLogger().info("Use auto-generated Build object")
-          pom.project.settings
-        }
-        else {
-          // This should not be reached
-          Seq()
-        }
+	pomFile.exists() match {
+	  case true =>
+            ConsoleLogger().info("Found a pom file at " + pomFile.getAbsolutePath())
+            val pom = Pom(pomFile)
+            val multiModuleBuild = !pom.modules.isEmpty
+            if (!multiModuleBuild) {
+              ConsoleLogger().info("Using auto-generated Build object")
+              pom.project.settings
+            } else {
+              Seq()
+            }
+
+	  case false =>
+            ConsoleLogger().info("POM not found at " + pomFile.getAbsolutePath())
+            Seq()
+	}
     }
-    ConsoleLogger().success("POM definition loaded")
+
     res
   }
 }


### PR DESCRIPTION
This seems to work for me.  I can build sbt-maven-plugin (an sbt project) with the sbt-maven-plugin specified in my global plugin settings, and build a maven project as well.  Feel free to reject this request if you think this is a bad idea. :wink: 
